### PR TITLE
Removes redundant canvas.draw() from canvasInit hook

### DIFF
--- a/gm-bg.js
+++ b/gm-bg.js
@@ -50,7 +50,7 @@ Hooks.on("canvasInit", async canvas => {
     if ( gmFlag && bg !== gmFlag) {
   
         canvas.scene.data.img = gmFlag;
-        return canvas.draw();
+        return;
     }
 });
 


### PR DESCRIPTION
Calling canvas.draw() within Hook canvasInit causes other Hooks.once('canvasInit' ...) hooks to trigger twice. This is because canvasInit is itself hooked within canvas.draw if the ready flag has not been set, but if you call canvas.draw() within init itself it will execute again before the original draw has had a chance to set ready, thus calling init a second time.

You can reproduce this issue by creating any other module and then adding a Hooks.once('canvasInit') which prints output to console, you will see output showing the double init such as:

```
    Foundry VTT | Drawing game canvas for scene Scene
    Foundry VTT | Drawing game canvas for scene Scene
    Simplefog | Adding Simplefog to canvas
    Simplefog | Rendering from: 0 to 27
    Simplefog | Adding Simplefog to canvas
    Simplefog | Rendering from: 0 to 27
```

canvasInit hooks trigger before the calls to render layer stacks, so for the purpose of this module I believe the call to canvas.draw() within canvasInit to be redundant, thus this PR fixes the issue by simply removing the canvas.draw() from that hook.